### PR TITLE
add ms-accent variable

### DIFF
--- a/_office.theme.vars.scss
+++ b/_office.theme.vars.scss
@@ -87,3 +87,6 @@ $ms-severeWarningText:		   "[theme:severeWarningText, default: #333333]";
 $ms-success:		           "[theme:success, default: #107c10]";
 $ms-successBackground:		   "[theme:successBackground, default: #dff6dd]";
 $ms-successText:		       "[theme:successText, default: #333333]";
+
+/* Misc Colors */
+$ms-accent:                "[theme:accent, default: #8764b8]";


### PR DESCRIPTION
I used the same color as you use for accent in your [css-variables.md](https://github.com/StfBauer/spfx-uifabric-themes/blob/master/docs/) docs.

**Note:** I didn't update any package numbers... just the single variable addition. 

See https://laurakokkarinen.com/how-to-create-a-multicolored-theme-for-a-modern-sharepoint-online-site/ for more info on use for theme:accent.